### PR TITLE
Fixing person search to correctly filter employees

### DIFF
--- a/app/controllers/wcms_components/people_controller.rb
+++ b/app/controllers/wcms_components/people_controller.rb
@@ -22,8 +22,8 @@ class WcmsComponents::PeopleController < ApplicationController
   private
 
   def permitted_people
-    # Return all people who are either employees or not private.
-    Person.where({'$or' => [{affiliations: ['employee'] }, {privacy: { '$ne' => true }}] })
+    # Return all people who are either employees, faculty, or not private.
+    Person.where({'$or' => [{affiliations: 'employee'}, {affiliations: 'faculty'}, {privacy: { '$ne' => true }}] })
   end
 
   def can_search_people?


### PR DESCRIPTION
It was filtering out people who were private and employees with an additional affiliation.

see: https://jira.biola.edu/browse/WR-604