### PR TITLE
Remove protect_from_forgery from shared controller

### DIFF
--- a/app/controllers/wcms_application_controller.rb
+++ b/app/controllers/wcms_application_controller.rb
@@ -2,8 +2,6 @@
 class WcmsApplicationController < ActionController::Base
   include Pundit
 
-  protect_from_forgery with: :exception
-
   before_action :authenticate!
   after_action :verify_authorized
   after_action :verify_policy_scoped, only: :index


### PR DESCRIPTION
The problem is that brakeman is looking for this line in the ApplicationController file and complaining because it is not there. For now we are just going to remove it here and add it back to each of the applications that use this gem.

@rift137 Can you make sure it is added back to all the projects before this gets merged?